### PR TITLE
Improve image layer caching of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM python:3
-
-RUN pip install discord.py
-RUN pip install varint
-RUN pip install sqlalchemy
-RUN pip install toml
-
 WORKDIR /app
+
+# allows better caching of image layers
+COPY requirements.txt /
+RUN pip install -r requirements.txt
 
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3
 WORKDIR /app
 
 # allows better caching of image layers
-COPY requirements.txt /
+COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY . /app


### PR DESCRIPTION
This PR fixes the `Dockerfile` by removing installing dependencies being installed via `RUN` commands.
This will make sure the layer that installs the dependencies will be cached and only rebuilt when `requirements.txt` is updated.

This fix assumes that the dependencies in `requirements.txt` is correct.