### PR TITLE
Added webmail_link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV password=
 ENV subject=
 ENV server=
 ENV port=
+ENV webmail_link=
 
 # discord
 ENV server_role=

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -26,13 +26,13 @@ class Verification(commands.Cog):
 			self.email_subject = os.environ["subject"]
 			self.email_server = os.environ["server"]
 			self.email_port = os.environ["port"]
-			self.webmail_link = os.environ["webmail_link"]
 
 			self.role = os.environ["server_role"]
 			self.channel_id = os.environ["channel_id"]
 			self.notify_id = os.environ["notify_id"]
 			self.admin_id = os.environ["admin_id"]
 			self.author_name = os.environ["author_name"]
+			self.webmail_link = os.environ["webmail_link"]
 
 			self.channel_id = int(self.channel_id)
 			self.notify_id = int(self.notify_id)
@@ -64,7 +64,9 @@ class Verification(commands.Cog):
 			f"your own email, keeping in mind that the bot only accepts email addresses with `@{self.verify_domain}` at the end. "
 			f"**Wait for an email to be received**. If you don't receive an email after 5 minutes, try using the email "
 			f"command again. **Send the command provided in the email** as a message in the {verify_email.mention} channel "
-			f"to gain access to the rest of the server.\n\n**Send messages in the {verify_email.mention} channel to use this "
+			f"to gain access to the rest of the server."
+			f"\n\n**You can access your webmail at {self.webmail_link}**"
+			f"\n\n**Send messages in the {verify_email.mention} channel to use this "
 			f"bot's commands, not in a DM.**")
 
 	# The email command handles all the checks done before an email is sent out alongside the actual email sending.

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -26,6 +26,7 @@ class Verification(commands.Cog):
 			self.email_subject = os.environ["subject"]
 			self.email_server = os.environ["server"]
 			self.email_port = os.environ["port"]
+			self.webmail_link = os.environ["webmail_link"]
 
 			self.role = os.environ["server_role"]
 			self.channel_id = os.environ["channel_id"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       # The port of the SMTP server above. The Gmail one is provided.
       - port=465
       # The role given to members who successfully verify.
+      - webmail_link=
+      # The link to access the email inboxes (ex: exchange, gsuite, etc.).
       - server_role=
       # The channel id for the verification channel.
       - channel_id=


### PR DESCRIPTION
The webmail link in vhelp was left out of the rewrite to make it less personalized to the specific server it was being used on, but it was requested to be reintroduced due to the coming surge of students in the fall.