### PR TITLE
Active token addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,14 @@ Here is a full list of the commands the bot offers:
 | verify          | Uses the token sent to the email account to verify the user.                                                | None                 | verify <token: int>                                        |
 | support         | Replies with links to financially support the authors and contributors of this bot, and a link to this repo | None                 | support                                                    |
 | uptime          | Tells you how long this instance of the bot has been running for.                                           | None                 | uptime                                                     |
+| activetokens    | Notifies the 'notification channel' of which users have incomplete verifications in progress.               | None                 | activetokens                                               |
 | prune           | Prunes the most recent *n* amount of messages in a channel.                                                 | Manage Server        | prune <amount: int>                                        |
 | modverify       | Allows you to manually verify a user, bypassing the main verification system.                               | Manage Server        | modverify <email: str> <userid: int>                       |
 | reactoradd      | Adds a reactor to a message                                                                                 | Manage Server        | reactoradd <message_id: str> <role_id: str> <emote: emote> |
 | reactordelete   | Removes all reactors from a message.                                                                        | Manage Server        | reactordelete <message_id: str>                            |
 | reactorget      | Get all reactors in the server                                                                              | Manage Server        | reactorget                                                 |
 | reactorclearall | Removes all reactors in the server.                                                                         | Manage Server        | reactorclearall                                            |
+
 
 \* `<>` = required, `[]` = optional
 

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -72,7 +72,7 @@ class Verification(commands.Cog):
 			f"\n\n**You can access your webmail at {self.webmail_link}**"
 			f"\nMake sure to check your junk email folder for the message in case it gets sent there."
 			f"\n\n**Send messages in the {verify_email.mention} channel to use this "
-			f"bot's commands, not in a DM.**")
+			f"bots commands, not in a DM.**")
 
 	# The email command handles all the checks done before an email is sent out alongside the actual email sending.
 	# It's very complicated.
@@ -173,7 +173,8 @@ class Verification(commands.Cog):
 					self.email_attempts[ctx.author.id] = 1
 
 			else:
-				await ctx.send(f"Invalid email {ctx.author.mention}!")
+				await ctx.send(f"Invalid email submitted, {ctx.author.mention}! Please submit an email in the format "
+							   f"`{self.bot_key}email {self.sample_username}@{self.verify_domain}` to verify your email.")
 
 	@commands.command(name="verify", aliases=["token", "Verify", "Token"])
 	@commands.guild_only()
@@ -229,7 +230,7 @@ class Verification(commands.Cog):
 						file.write(f"{hashed}\n")
 						file.close()
 				else:
-					await ctx.send(f"Invalid token {ctx.author.mention}!")
+					await ctx.send(f"Invalid token submitted, {ctx.author.mention}! Please submit the 4-digit token send to your email to verify.")
 					if self.verify_attempts:
 						if ctx.author.id in self.verify_attempts:
 							self.verify_attempts[ctx.author.id] += 1
@@ -281,6 +282,13 @@ class Verification(commands.Cog):
 		else:  # if user isn't found
 			print(f"User with id {userid} not found")
 			await ctx.send(f"{ctx.author.mention}, the user with id {userid} was not found.")
+
+	@commands.command(name="active_tokens", aliases=["verify_in_progress", "in_progress", "activetokens", "verifyinprogress", "inprogress"])
+	@commands.guild_only()
+	async def _active_tokens(self, ctx):
+		print(f"Printing active tokens to notification chat.")
+		sendIn = ctx.guild.get_channel(self.notify_id)
+		await sendIn.send(f"Active verification tokens: \n{self.token_list}")
 
 
 def setup(bot):


### PR DESCRIPTION
Added 'active tokens', a way to check people who sent an email to themselves but then never verified with the token. Helpful for when you need to restart the bot and see who will be affected.

Added extra help info to the invalid email and token handlers at the request of a moderator of the UVic ECS Discord server.