### PR TITLE
Email handling fixes, command cleanup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,8 +1,7 @@
 import os.path as osp
 import os
-# import smtplib
-# import ssl
 import random
+import time
 
 import discord
 from discord.ext import commands
@@ -47,8 +46,8 @@ except KeyError as e:
 	print(f"Config error.\n\tKey Not Loaded: {e}")
 	do_run = False
 
-# Seed the random number generator from the bot token.
-random.seed(bot_token)
+# Seed the random number generator from the system time. (This used to be the bot token. I'm not sure why.)
+random.seed(int(time.time()))
 
 # From the used_emails filename, load the data from the data folder. This can be commented out if not using a data folder.
 used_emails = osp.join(current_dir, data_path, used_emails)


### PR DESCRIPTION
-Cleaned up the output from 'active tokens', usernames are now insert…ed where there used to be plain tokens.
-Removed some remaining messaging specific to the UVic ECS discord server in the email body. All server-specific elements should now be removed. (If some haven't been, please submit an issue report!)
-Modified the SMTP sending code - it *should* be able to handle more email servers. Specifically, it was tested with Outlook (as Gmail is disabling SMTP altogether on May 30th). If there is a compatability regression from this change, please submit an issue report!
-Switched the random number generator to be seeded based on the system time, rather than the bot token. I have no idea why it was seeded based on the bot token, but apparently I wrote that code last year, and I only noticed it because I kept getting the same token between restarts of the bot. Whoops.